### PR TITLE
fix attribute name `inputs_names`

### DIFF
--- a/optimum/onnxruntime/io_binding/io_binding_helper.py
+++ b/optimum/onnxruntime/io_binding/io_binding_helper.py
@@ -157,9 +157,9 @@ class IOBindingHelper:
         Returns an IOBinding object for an inference session. This method is for general purpose, if the inputs and outputs
         are determined, you can prepare data buffers directly to avoid tensor transfers across frameworks.
         """
-        if not all(input_name in inputs.keys() for input_name in ort_model.inputs_names):
+        if not all(input_name in inputs.keys() for input_name in ort_model.input_names):
             raise ValueError(
-                f"The ONNX model takes {ort_model.inputs_names.keys()} as inputs, but only {inputs.keys()} are given."
+                f"The ONNX model takes {ort_model.input_names.keys()} as inputs, but only {inputs.keys()} are given."
             )
 
         name_to_np_type = TypeHelper.get_io_numpy_type_map(ort_model.model)
@@ -168,7 +168,7 @@ class IOBindingHelper:
         io_binding = ort_model.model.io_binding()
 
         # Bind inputs
-        for input_name in ort_model.inputs_names:
+        for input_name in ort_model.input_names:
             onnx_input = inputs.pop(input_name)
             onnx_input = onnx_input.contiguous()
 


### PR DESCRIPTION
# What does this PR do?
- fix attribute name of ORTmodel from `inputs_names` to `input_names`.
Because [ORTmodel](https://github.com/huggingface/optimum/blob/main/optimum/onnxruntime/modeling_ort.py#L271) has no attribute named `inputs_names` but `input_names`.



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
This could be a solution for #1992 .

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
